### PR TITLE
Add doctrine/dbal to composer.json require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "require": {
         "php": ">=5.3.0",
         "illuminate/support": "~4",
-        "fzaninotto/faker": "1.3.*@dev"
+        "fzaninotto/faker": "1.3.*@dev",
+        "doctrine/dbal": "dev-master@dev"
     },
     "require-dev": {
         "mockery/mockery": "dev-master@dev"


### PR DESCRIPTION
Added doctrine/dbal to composer.json as it seems doctrine/dbal is required for fakefactory to work and it is no longer included in Laravel by default.

http://laravel.com/docs/releases#laravel-4.1
